### PR TITLE
Add password_reset template

### DIFF
--- a/project/fifty_fifty/fifty_fifty/urls.py
+++ b/project/fifty_fifty/fifty_fifty/urls.py
@@ -18,6 +18,8 @@ from django.conf.urls.static import static
 from django.conf.urls import url, include
 from django.contrib import admin
 from webcore import views
+from allauth.account.views import PasswordResetView
+
 admin.autodiscover()
 
 urlpatterns = [
@@ -32,7 +34,8 @@ urlpatterns = [
     url(r'^profile/profile.html', views.userProfileProfile, name='profileProfile'),
     url(r'^profile/menteelogin.html', views.userProfile, name='profile'),
     url(r'^profile/contact.html', views.userProfileContact, name='profileContact'),
-
+    
+    url(r'^accounts/password/reset', views.PasswordResetView.as_view(template_name='password_reset.html')),
     url(r'^accounts/', include('allauth.urls')),
     url(r'^content/', include('content.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/project/fifty_fifty/webcore/templates/password_reset.html
+++ b/project/fifty_fifty/webcore/templates/password_reset.html
@@ -1,0 +1,25 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load account %}
+
+{% block head_title %}{% trans "Password Reset" %}{% endblock %}
+
+{% block content %}
+  <div class="container">
+    <h1>{% trans "Password Reset" %}</h1>
+    {% if user.is_authenticated %}
+    {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+
+    <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
+
+    <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" value="{% trans 'Reset My Password' %}" />
+    </form>
+    <br />
+    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+   </div>
+{% endblock %}


### PR DESCRIPTION
Fixed the bootstrap container div issue. Now the form at  /accounts/password/reset is displayed properly.